### PR TITLE
Update Dapr extension for AKS document to add details for managing Dapr versioning

### DIFF
--- a/articles/aks/dapr-settings.md
+++ b/articles/aks/dapr-settings.md
@@ -189,16 +189,27 @@ If you want to use an outbound proxy with the Dapr extension for AKS, you can do
    - `NO_PROXY`
 1. [Installing the proxy certificate in the sidecar](https://docs.dapr.io/operations/configuration/install-certificates/).
 
+## Updating your Dapr installation version
+
+If you are on a specific Dapr version and you don't have `--auto-upgrade-minor-version` available, you can use the following command to upgrade or downgrade Dapr:
+
+```azurecli
+az k8s-extension update --cluster-type managedClusters \
+--cluster-name myAKSCluster \
+--resource-group myResourceGroup \
+--name dapr \
+--version 1.12.0 # Version to upgrade or downgrade to
+```
+
 ## Using Azure Linux-based images
 
 From Dapr version 1.8.0, you can use Azure Linux images with the Dapr extension. To use them, set the`global.tag` flag:
 
 ```azurecli
-az k8s-extension upgrade --cluster-type managedClusters \
+az k8s-extension update --cluster-type managedClusters \
 --cluster-name myAKSCluster \
 --resource-group myResourceGroup \
 --name dapr \
---extension-type Microsoft.Dapr \
 --set global.tag=1.10.0-mariner
 ```
 
@@ -211,16 +222,10 @@ az k8s-extension upgrade --cluster-type managedClusters \
 With Dapr version 1.9.2, CRDs are automatically upgraded when the extension upgrades. To disable this setting, you can set `hooks.applyCrds` to `false`. 
 
 ```azurecli
-az k8s-extension upgrade --cluster-type managedClusters \
+az k8s-extension update --cluster-type managedClusters \
 --cluster-name myAKSCluster \
 --resource-group myResourceGroup \
 --name dapr \
---extension-type Microsoft.Dapr \
---auto-upgrade-minor-version true \
---configuration-settings "global.ha.enabled=true" \
---configuration-settings "dapr_operator.replicaCount=2" \
---configuration-settings "global.daprControlPlaneOs=linux” \
---configuration-settings "global.daprControlPlaneArch=amd64” \
 --configuration-settings "hooks.applyCrds=false"
 ```
 

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -157,17 +157,23 @@ When installing the Dapr extension, use the flag value that corresponds to your 
 > [!NOTE]
 > If you're using Dapr OSS on your AKS cluster and would like to install the Dapr extension for AKS, read more about [how to successfully migrate to the Dapr extension][dapr-migration]. 
 
-Create the Dapr extension, which installs Dapr on your AKS or Arc-enabled Kubernetes cluster. For example, for an AKS cluster:
+Create the Dapr extension, which installs Dapr on your AKS or Arc-enabled Kubernetes cluster. 
 
+For example, install the latest version of Dapr via the Dapr extension on your AKS cluster:
 ```azurecli
 az k8s-extension create --cluster-type managedClusters \
 --cluster-name myAKSCluster \
 --resource-group myResourceGroup \
 --name dapr \
---extension-type Microsoft.Dapr
+--extension-type Microsoft.Dapr \
+--auto-upgrade-minor-version false
 ```
 
-You have the option of allowing Dapr to auto-update its minor version by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `true`:
+You have the option of allowing Dapr to auto-update its minor version by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `true`. 
+Note, the versioning of Dapr is in the format `MAJOR.MINOR.PATCH`, which means `1.11.0` to `1.12.0` is a minor version upgrade.
+
+> [!WARNING]
+> For production environments, we do not recommend enabling auto-upgrade-minor-version. This option is suitable for dev or test environments only.
 
 ```azurecli
 --auto-upgrade-minor-version true
@@ -191,7 +197,7 @@ For example:
 > [!NOTE]
 > Dapr is supported with a rolling window, including only the current and previous versions. It is your operational responsibility to remain up to date with these supported versions. If you have an older version of Dapr, you may have to do intermediate upgrades to get to a supported version.
 
-The same command-line argument is used for installing a specific version of Dapr or rolling back to a previous version. Set `--auto-upgrade-minor-version` to `false` and `--version` to the version of Dapr you wish to install. If the `version` parameter is omitted, the extension installs the latest version of Dapr. For example, to use Dapr X.X.X: 
+The same command-line argument is used for installing a specific version of Dapr or rolling back to a previous version. Set `--auto-upgrade-minor-version` to `false` and `--version` to the version of Dapr you wish to install. If the `version` parameter is omitted, the extension installs the latest version of Dapr. For example, to use Dapr X.X.X:
 
 ```azurecli
 az k8s-extension create --cluster-type managedClusters \


### PR DESCRIPTION
This PR
- Warns users to not use auto-upgrade in prod
- Explain auto-upgrade with an example
- Fixes `upgrade` command to use `update`
- Adds docs on upgrading/downgrading Dapr